### PR TITLE
fix(types): making optional useSetup/createSetup props argument.

### DIFF
--- a/packages/reactivue/src/createSetup.ts
+++ b/packages/reactivue/src/createSetup.ts
@@ -1,3 +1,3 @@
 import { useSetup } from './useSetup'
 
-export const createSetup = <Props, State>(setupFn: (props: Props) => State) => (props: Props) => useSetup(setupFn, props)
+export const createSetup = <Props, State>(setupFn: (props?: Props) => State) => (props: Props) => useSetup(setupFn, props)

--- a/packages/reactivue/src/createSetup.ts
+++ b/packages/reactivue/src/createSetup.ts
@@ -1,3 +1,3 @@
 import { useSetup } from './useSetup'
 
-export const createSetup = <Props, State>(setupFn: (props?: Props) => State) => (props: Props) => useSetup(setupFn, props)
+export const createSetup = <Props, State>(setupFn: (props?: Props) => State) => (props?: Props) => useSetup(setupFn, props)

--- a/packages/reactivue/src/useSetup.ts
+++ b/packages/reactivue/src/useSetup.ts
@@ -7,14 +7,14 @@ import { LifecycleHooks } from './types'
 
 export function useSetup<State, Props = {}>(
   setupFunction: (props: Props) => State,
-  Props: Props,
+  ReactProps?: Props,
 ): UnwrapRef<State> {
   const [id] = useState(getNewInstanceId)
   const setTick = useState(0)[1]
 
   // run setup function
   const [state] = useState(() => {
-    const props = reactive({ ...(Props || {}) }) as any
+    const props = reactive({ ...(ReactProps || {}) }) as any
     const instance = createNewInstanceWithId(id, props)
 
     useInstanceScope(id, () => {
@@ -30,16 +30,16 @@ export function useSetup<State, Props = {}>(
 
   // sync props changes
   useEffect(() => {
-    if (!Props) return
+    if (!ReactProps) return
 
     useInstanceScope(id, (instance) => {
       if (!instance)
         return
       const { props } = instance
-      for (const key of Object.keys(Props))
-        props[key] = (Props as any)[key]
+      for (const key of Object.keys(ReactProps))
+        props[key] = (ReactProps as any)[key]
     })
-  }, [Props])
+  }, [ReactProps])
 
   // trigger React re-render on data changes
   useEffect(() => {


### PR DESCRIPTION
In the useSetup the IDE show me a warning because the name of the generic type and the props variable that comes from React are the same.

`'Props' is already defined.eslint@typescript-eslint/no-redeclare`

![Screenshot 2020-11-21 194833](https://user-images.githubusercontent.com/50024128/99891294-4278c800-2c36-11eb-835b-e44074f43ef7.png)

So I rename the props that comes from React to avoid the typescript warning.
