### PR TITLE
feat: add preact support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .cache
 packages/reactivue/README.md
 .idea/
+preact

--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ export const Counter = (props: Props) => {
 }
 ```
 
+## Usage with Preact
+
+To use reactivue in Preact apps, just replace `reactivue` import with `reactivue/preact`
+
+```diff
+import { h } from 'preact'
+-import { defineComponent, ref, computed, onUnmounted } from 'reactivue'
++import { defineComponent, ref, computed, onUnmounted } from 'reactivue/preact'
+```
+
 ## Using Vue's Libraries
 
 *Yes, you can!* Before you start, you need set alias in your build tool in order to redirect some apis from `vue` to `reactivue`.
@@ -165,6 +175,18 @@ Add following code to `vite.config.js`
   alias: {
     'vue': 'reactivue',
     '@vue/runtime-dom': 'reactivue',
+  }
+}
+```
+
+If you are using it with Preact you have to add following code to `vite.config.js`
+
+```ts
+{
+  /* ... */
+  optimizeDeps: {
+    include: ['reactivue/preact'],
+    exclude: ['@vue/reactivity']
   }
 }
 ```

--- a/packages/reactivue/package.json
+++ b/packages/reactivue/package.json
@@ -15,7 +15,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "preact"
   ],
   "sideEffects": false,
   "repository": {

--- a/packages/reactivue/package.json
+++ b/packages/reactivue/package.json
@@ -7,7 +7,13 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "browser": "dist/index.esm.js",
-  "typing": "dist/index.d.ts",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "./preact": {
+      "import": "./preact/index.esm.js",
+      "require": "./preact/index.js"
+    }
+  },
   "files": [
     "dist"
   ],
@@ -33,7 +39,9 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^10.0.0",
+    "@rollup/plugin-replace": "^2.3.4",
     "cac": "^6.6.1",
+    "preact": "^10.5.9",
     "react": "^17.0.1",
     "rollup": "^2.33.0",
     "rollup-plugin-dts": "^1.4.13",
@@ -42,6 +50,7 @@
     "typescript": "^4.0.5"
   },
   "peerDependencies": {
+    "preact": "^10.5.9",
     "react": ">=16"
   },
   "dependencies": {

--- a/packages/reactivue/rollup.config.js
+++ b/packages/reactivue/rollup.config.js
@@ -1,8 +1,9 @@
 import typescript from 'rollup-plugin-typescript2'
 import dts from 'rollup-plugin-dts'
 import resolve from '@rollup/plugin-node-resolve'
+import replace from '@rollup/plugin-replace'
 
-const external = ['@vue/reactivity', 'react']
+const external = ['@vue/reactivity', 'react', 'preact/hooks']
 
 export default [
   {
@@ -26,10 +27,35 @@ export default [
   },
   {
     input: 'src/index.ts',
-    output: {
-      file: 'dist/index.d.ts',
-      format: 'es',
+    output: [
+      {
+        file: 'preact/index.js',
+        format: 'cjs',
+      },
+      {
+        file: 'preact/index.esm.js',
+        format: 'es',
+      },
+    ],
+    plugins: [replace({ react: 'preact/hooks' }), resolve(), typescript()],
+    external,
+    onwarn(msg, warn) {
+      if (!/Circular/.test(msg))
+        warn(msg)
     },
+  },
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        file: 'dist/index.d.ts',
+        format: 'es',
+      },
+      {
+        file: 'preact/index.d.ts',
+        format: 'es',
+      },
+    ],
     plugins: [dts()],
     external,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,6 +305,14 @@
     is-module "^1.0.0"
     resolve "^1.17.0"
 
+"@rollup/plugin-replace@^2.3.4":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-2.3.4.tgz#7dd84c17755d62b509577f2db37eb524d7ca88ca"
+  integrity sha512-waBhMzyAtjCL1GwZes2jaE9MjuQ/DQF2BatH3fRivUF3z0JBFrU0U6iBNC/4WR+2rLKhaAhPWDNPYp4mI6RqdQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    magic-string "^0.25.7"
+
 "@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.0.9", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
@@ -3127,6 +3135,11 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.11, postcss@^7.0.14, postcss@^7.0.1
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+preact@^10.5.9:
+  version "10.5.9"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.9.tgz#8caba9288b4db1d593be2317467f8735e43cda0b"
+  integrity sha512-X4m+4VMVINl/JFQKALOCwa3p8vhMAhBvle0hJ/W44w/WWfNb2TA7RNicDV3K2dNVs57f61GviEnVLiwN+fxiIg==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
I tested it on vite 2.0 with preact template. As ar as i see it works.

When configuring `exports` fields in `package.json` i take this https://github.com/microsoft/TypeScript/issues/33079#issuecomment-738033267 comment as a reference for proper typescript support.

Also renamed `typing` field to `types`, i dont know does it break something or not but this is more common. 

My vite config for testing this feature:
```ts
import preactRefresh from '@prefresh/vite'
import { defineConfig } from 'vite'

export default defineConfig({
  esbuild: {
    jsxFactory: 'h',
    jsxFragment: 'Fragment'
  },
  plugins: [preactRefresh()],
  optimizeDeps: {
    include: ['reactivue/preact'],
    exclude: ['@vue/reactivity']
  }
})

```

I can update examples asap if this pr get merged.