### PR TITLE
fix: keep reactivity after hmr updates

### DIFF
--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -47,10 +47,10 @@ export const unmountInstance = (id: number) => {
   _vueState[id].isUnmounting = true
 
   const unmount = async() => {
-    if (!_vueState[id].isUnmounting)
-      return
-
     if (_vueState[id]) {
+      if (!_vueState[id].isUnmounting)
+        return
+
       invokeLifeCycle(LifecycleHooks.BEFORE_UNMOUNT, _vueState[id])
       // unregister all the computed/watch effects
       for (const effect of _vueState[id].effects || [])

--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-mutable-exports */
 import { Ref, ReactiveEffect, ref, stop } from '@vue/reactivity'
+import { isDev } from './env'
 import { invokeLifeCycle } from './lifecycle'
 import { InternalInstanceState, LifecycleHooks } from './types'
 
@@ -27,7 +28,7 @@ export const createNewInstanceWithId = (id: number, props: any, data: Ref<any> =
     props,
     data,
     isUnmounted: false,
-    willUnmount: false,
+    isUnmounting: false,
     hooks: {},
     initialState: {},
   }
@@ -43,10 +44,10 @@ export const useInstanceScope = (id: number, cb: (instance: InternalInstanceStat
 }
 
 export const unmountInstance = (id: number) => {
-  _vueState[id].willUnmount = true
+  _vueState[id].isUnmounting = true
 
   const unmount = async() => {
-    if (!_vueState[id].willUnmount)
+    if (!_vueState[id].isUnmounting)
       return
 
     if (_vueState[id]) {
@@ -68,7 +69,7 @@ export const unmountInstance = (id: number) => {
    * for really unmounting components. Because they are increasing
    * instance id unlike the hmr updated components.
    */
-  if (process.env.NODE_ENV === 'development') {
+  if (isDev) {
     setTimeout(unmount, 1000)
     return
   }

--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -9,7 +9,6 @@ const _vueState: Record<number, InternalInstanceState> = {}
 export let currentInstance: InternalInstanceState | null = null
 export let currentInstanceId: number | null = null
 
-export const isInstanceExist = (id: number) => !!_vueState[id]
 export const getNewInstanceId = () => _id++
 export const getCurrentInstance = () => currentInstance
 export const setCurrentInstance = (
@@ -28,7 +27,9 @@ export const createNewInstanceWithId = (id: number, props: any, data: Ref<any> =
     props,
     data,
     isUnmounted: false,
+    willUnmount: false,
     hooks: {},
+    initialState: {},
   }
   _vueState[id] = instance
   return instance
@@ -42,17 +43,36 @@ export const useInstanceScope = (id: number, cb: (instance: InternalInstanceStat
 }
 
 export const unmountInstance = (id: number) => {
-  if (_vueState[id]) {
-    invokeLifeCycle(LifecycleHooks.BEFORE_UNMOUNT, _vueState[id])
-    // unregister all the computed/watch effects
-    for (const effect of _vueState[id].effects || [])
-      stop(effect)
-    invokeLifeCycle(LifecycleHooks.UNMOUNTED, _vueState[id])
-    _vueState[id].isUnmounted = true
+  _vueState[id].willUnmount = true
+
+  const unmount = async() => {
+    if (!_vueState[id].willUnmount)
+      return
+
+    if (_vueState[id]) {
+      invokeLifeCycle(LifecycleHooks.BEFORE_UNMOUNT, _vueState[id])
+      // unregister all the computed/watch effects
+      for (const effect of _vueState[id].effects || [])
+        stop(effect)
+      invokeLifeCycle(LifecycleHooks.UNMOUNTED, _vueState[id])
+      _vueState[id].isUnmounted = true
+    }
+
+    // release the ref
+    delete _vueState[id]
   }
 
-  // release the ref
-  delete _vueState[id]
+  /**
+   * Postpone unmounting on dev. So we can check setup values
+   * in useSetup.ts after hmr updates. That will not be an issue
+   * for really unmounting components. Because they are increasing
+   * instance id unlike the hmr updated components.
+   */
+  if (process.env.NODE_ENV === 'development') {
+    setTimeout(unmount, 1000)
+    return
+  }
+  unmount()
 }
 
 // record effects created during a component's setup() so that they can be

--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -9,6 +9,7 @@ const _vueState: Record<number, InternalInstanceState> = {}
 export let currentInstance: InternalInstanceState | null = null
 export let currentInstanceId: number | null = null
 
+export const isInstanceExist = (id: number) => !!_vueState[id]
 export const getNewInstanceId = () => _id++
 export const getCurrentInstance = () => currentInstance
 export const setCurrentInstance = (

--- a/packages/reactivue/src/env.ts
+++ b/packages/reactivue/src/env.ts
@@ -1,2 +1,3 @@
 // TODO: should be repaced with bundle global injection
 export const __DEV__ = true
+export const isDev = process?.env?.NODE_ENV === 'development'

--- a/packages/reactivue/src/env.ts
+++ b/packages/reactivue/src/env.ts
@@ -1,3 +1,3 @@
 // TODO: should be repaced with bundle global injection
 export const __DEV__ = true
-export const isDev = process?.env?.NODE_ENV === 'development'
+export const isDev = typeof process !== 'undefined' && process.env.NODE_ENV === 'development'

--- a/packages/reactivue/src/types.ts
+++ b/packages/reactivue/src/types.ts
@@ -16,6 +16,8 @@ export interface InternalInstanceState {
   props: any
   data: Ref<any>
   isUnmounted: boolean
+  willUnmount: boolean
   effects?: ReactiveEffect[]
   hooks: Record<string, Function[]>
+  initialState: Record<any, any>
 }

--- a/packages/reactivue/src/types.ts
+++ b/packages/reactivue/src/types.ts
@@ -16,7 +16,7 @@ export interface InternalInstanceState {
   props: any
   data: Ref<any>
   isUnmounted: boolean
-  willUnmount: boolean
+  isUnmounting: boolean
   effects?: ReactiveEffect[]
   hooks: Record<string, Function[]>
   initialState: Record<any, any>

--- a/packages/reactivue/src/useSetup.ts
+++ b/packages/reactivue/src/useSetup.ts
@@ -98,7 +98,7 @@ export function useSetup<State extends Record<any, any>, Props = {}>(
            * Prevent triggering rerender when component
            * is about to unmount or really unmounted
            */
-          if (instance.isUnmounting)
+          if (!instance || instance.isUnmounting)
             return
 
           useInstanceScope(id, () => {

--- a/packages/reactivue/src/useSetup.ts
+++ b/packages/reactivue/src/useSetup.ts
@@ -12,8 +12,7 @@ export function useSetup<State, Props = {}>(
   const [id] = useState(getNewInstanceId)
   const setTick = useState(0)[1]
 
-  // run setup function
-  const [state] = useState(() => {
+  const createState = () => {
     const props = reactive({ ...(ReactProps || {}) }) as any
     const instance = createNewInstanceWithId(id, props)
 
@@ -26,7 +25,10 @@ export function useSetup<State, Props = {}>(
     })
 
     return instance.data.value
-  })
+  }
+
+  // run setup function
+  const [state, setState] = useState(createState)
 
   // sync props changes
   useEffect(() => {
@@ -43,6 +45,8 @@ export function useSetup<State, Props = {}>(
 
   // trigger React re-render on data changes
   useEffect(() => {
+    setState(createState())
+
     useInstanceScope(id, (instance) => {
       if (!instance)
         return

--- a/packages/reactivue/src/useSetup.ts
+++ b/packages/reactivue/src/useSetup.ts
@@ -1,6 +1,6 @@
 import { UnwrapRef, reactive, ref, readonly } from '@vue/reactivity'
 import { useState, useEffect } from 'react'
-import { getNewInstanceId, createNewInstanceWithId, useInstanceScope, unmountInstance } from './component'
+import { getNewInstanceId, createNewInstanceWithId, useInstanceScope, unmountInstance, isInstanceExist } from './component'
 import { watch } from './watch'
 import { invokeLifeCycle } from './lifecycle'
 import { LifecycleHooks } from './types'
@@ -45,7 +45,8 @@ export function useSetup<State, Props = {}>(
 
   // trigger React re-render on data changes
   useEffect(() => {
-    setState(createState())
+    if (!isInstanceExist(id))
+      setState(createState())
 
     useInstanceScope(id, (instance) => {
       if (!instance)

--- a/packages/reactivue/src/useSetup.ts
+++ b/packages/reactivue/src/useSetup.ts
@@ -25,8 +25,10 @@ export function useSetup<State extends Record<any, any>, Props = {}>(
 
       instance.data = data
 
-      for (const key of Object.keys(setupState))
-        instance.initialState[key] = unref(setupState[key])
+      if (isDev) {
+        for (const key of Object.keys(setupState))
+          instance.initialState[key] = unref(setupState[key])
+      }
     })
 
     return instance.data.value


### PR DESCRIPTION
Fix #11 

Not really a fix, actually it is a workaround.

I call it workaround, because it is works differently than vanilla React components.
Vanilla React components are keep states across HMR updates until you change initial state.

But with this PR, resets Reactivue state to its initial state after every HMR update. I think this is better than current behaviour. In current status, HMR updates completely killing reactivity until reloading page manually.

Also tested in Preact. Work as expected.
