### PR TITLE
fix: watchEffect now runs as-expected

### DIFF
--- a/packages/reactivue/src/watch.ts
+++ b/packages/reactivue/src/watch.ts
@@ -199,7 +199,7 @@ function doWatch(
     scheduler = job
   }
   else if (flush === 'post') {
-    scheduler = job => job()
+    scheduler = () => job()
     // TODO: scheduler = () => queuePostRenderEffect(job, instance && instance.suspense)
   }
   else {


### PR DESCRIPTION
It seems that `applyCb` was being marked as `undefined` when `watchEffect` called `doWatch`. This PR updates the code to more closely resemble the code that lives within `vue-next` (currently) and fixes this issue

Confirmed to work as-expected - it passes the tests that were previously marked as `.skip` in #12.

Closes #10 