### PR TITLE
Added back watcheffect tests

### DIFF
--- a/packages/reactivue/tests/watch.spec.tsx
+++ b/packages/reactivue/tests/watch.spec.tsx
@@ -39,9 +39,7 @@ it('should handle watch ref', async() => {
   })
 })
 
-// TODO: This test does not pass due to a bug in the library
-// @see https://github.com/antfu/reactivue/issues/10
-it.skip('should handle watchEffect ref', async() => {
+it('should handle watchEffect ref', async() => {
   const comp = render(<WatchTest hello={'Hello, world'}/>)
 
   comp.rerender(<WatchTest hello={'Adios, world'}/>)


### PR DESCRIPTION
When the tests PR got merged, it originally skipped this test due to the `watchEffect` bug. However, now that that bug's been quashed, this test can now be safely re-enabled, as it passes