### PR TITLE
refactor: cleanup

### DIFF
--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -4,11 +4,13 @@ import { isDev } from './env'
 import { invokeLifeCycle } from './lifecycle'
 import { InternalInstanceState, LifecycleHooks } from './types'
 
+type ReactiveEffects = Record<number, InternalInstanceState>
+
 declare global {
-  interface Window { _reactivueState: Record<number, InternalInstanceState> }
+  interface Window { _reactivueState: ReactiveEffects }
 }
 
-const _vueState: Record<number, InternalInstanceState> = window._reactivueState || {}
+const _vueState: ReactiveEffects = window._reactivueState || {}
 
 export let currentInstance: InternalInstanceState | null = null
 export let currentInstanceId: number | null = null

--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -10,7 +10,7 @@ declare global {
   interface Window { _reactivueState: ReactiveEffects }
 }
 
-const _vueState: ReactiveEffects = window._reactivueState || {}
+const _vueState: ReactiveEffects = window?._reactivueState || {}
 
 export let currentInstance: InternalInstanceState | null = null
 export let currentInstanceId: number | null = null
@@ -47,7 +47,9 @@ export const createNewInstanceWithId = (id: number, props: any, data: Ref<any> =
     initialState: {},
   }
   _vueState[id] = instance
-  window._reactivueState = _vueState
+
+  if (window)
+    window._reactivueState = _vueState
 
   return instance
 }
@@ -72,7 +74,8 @@ const unmount = (id: number) => {
 
   // release the ref
   delete _vueState[id]
-  window._reactivueState = _vueState
+  if (window)
+    window._reactivueState = _vueState
 }
 
 export const unmountInstance = (id: number) => {

--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -13,7 +13,7 @@ export const getNewInstanceId = () => {
   // When React is in Strict mode, it runs state functions twice
   // Remove unmounted instances before creating new one
   if (isDev)
-    Object.keys(_vueState).forEach(id => !_vueState[+id].isActive && unmount(+id, false))
+    Object.keys(_vueState).forEach(id => !_vueState[+id].isActive && unmount(+id))
 
   return Object.keys(_vueState).length
 }
@@ -52,10 +52,7 @@ export const useInstanceScope = (id: number, cb: (instance: InternalInstanceStat
   setCurrentInstanceId(prev)
 }
 
-const unmount = (id: number, active = true) => {
-  if (!_vueState[id]?.isUnmounting && active)
-    return
-
+const unmount = (id: number) => {
   invokeLifeCycle(LifecycleHooks.BEFORE_UNMOUNT, _vueState[id])
 
   // unregister all the computed/watch effects
@@ -83,7 +80,7 @@ export const unmountInstance = (id: number) => {
    * instance id unlike the hmr updated components.
    */
   if (isDev) {
-    setTimeout(async() => unmount(id))
+    setTimeout(async() => _vueState[id]?.isUnmounting && unmount(id), 1)
     return
   }
   unmount(id)

--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -10,7 +10,7 @@ declare global {
   interface Window { _reactivueState: ReactiveEffects }
 }
 
-const _vueState: ReactiveEffects = window && isDev ? window._reactivueState : {}
+const _vueState: ReactiveEffects = (isDev && window && window._reactivueState) || {}
 
 export let currentInstance: InternalInstanceState | null = null
 export let currentInstanceId: number | null = null

--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -71,6 +71,9 @@ const unmount = (id: number, active = true) => {
 }
 
 export const unmountInstance = (id: number) => {
+  if (!_vueState[id])
+    return
+
   _vueState[id].isUnmounting = true
 
   /**

--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -80,7 +80,7 @@ export const unmountInstance = (id: number) => {
    * instance id unlike the hmr updated components.
    */
   if (isDev) {
-    setTimeout(async() => _vueState[id]?.isUnmounting && unmount(id), 1)
+    setTimeout(async() => _vueState[id]?.isUnmounting && unmount(id))
     return
   }
   unmount(id)

--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -91,7 +91,7 @@ export const unmountInstance = (id: number) => {
    * instance id unlike the hmr updated components.
    */
   if (isDev) {
-    setTimeout(async() => _vueState[id]?.isUnmounting && unmount(id))
+    setTimeout(() => _vueState[id]?.isUnmounting && unmount(id), 0)
     return
   }
   unmount(id)

--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -27,7 +27,10 @@ export const getNewInstanceId = () => {
   // When React is in Strict mode, it runs state functions twice
   // Remove unmounted instances before creating new one
   if (isDev)
-    Object.keys(_vueState).forEach(id => !_vueState[+id].isActive && unmount(+id))
+    Object.keys(_vueState).forEach(id => {
+      if (!_vueState[id].isActive)
+        unmount(id)
+    })
 
   return Object.keys(_vueState).length
 }

--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -4,7 +4,11 @@ import { isDev } from './env'
 import { invokeLifeCycle } from './lifecycle'
 import { InternalInstanceState, LifecycleHooks } from './types'
 
-const _vueState: Record<number, InternalInstanceState> = {}
+declare global {
+  interface Window { _reactivueState: Record<number, InternalInstanceState> }
+}
+
+const _vueState: Record<number, InternalInstanceState> = window._reactivueState || {}
 
 export let currentInstance: InternalInstanceState | null = null
 export let currentInstanceId: number | null = null
@@ -41,6 +45,7 @@ export const createNewInstanceWithId = (id: number, props: any, data: Ref<any> =
     initialState: {},
   }
   _vueState[id] = instance
+  window._reactivueState = _vueState
 
   return instance
 }
@@ -65,6 +70,7 @@ const unmount = (id: number) => {
 
   // release the ref
   delete _vueState[id]
+  window._reactivueState = _vueState
 }
 
 export const unmountInstance = (id: number) => {

--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -10,7 +10,7 @@ declare global {
   interface Window { _reactivueState: ReactiveEffects }
 }
 
-const _vueState: ReactiveEffects = window?._reactivueState || {}
+const _vueState: ReactiveEffects = window && isDev ? window._reactivueState : {}
 
 export let currentInstance: InternalInstanceState | null = null
 export let currentInstanceId: number | null = null
@@ -48,7 +48,7 @@ export const createNewInstanceWithId = (id: number, props: any, data: Ref<any> =
   }
   _vueState[id] = instance
 
-  if (window)
+  if (window && isDev)
     window._reactivueState = _vueState
 
   return instance
@@ -74,7 +74,7 @@ const unmount = (id: number) => {
 
   // release the ref
   delete _vueState[id]
-  if (window)
+  if (window && isDev)
     window._reactivueState = _vueState
 }
 

--- a/packages/reactivue/src/types.ts
+++ b/packages/reactivue/src/types.ts
@@ -15,6 +15,7 @@ export interface InternalInstanceState {
   _id: number
   props: any
   data: Ref<any>
+  isActive: boolean
   isUnmounted: boolean
   isUnmounting: boolean
   effects?: ReactiveEffect[]


### PR DESCRIPTION
there are few things done in this pr:

- removing stale instances on react strict mode #21 
- generating `id`'s based on `_vueState` length. because strict mode was increasing it twice on dev, once on prod. now both of them in sync.
- removed 1s delay on delayed unmount function. settimeout already makes it run in next tick.