### PR TITLE
fix: update package.json to support node16 moduleResolution

### DIFF
--- a/packages/reactivue/package.json
+++ b/packages/reactivue/package.json
@@ -10,6 +10,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "browser": {
         "production": "./dist/index.module.js",
         "development": "./dist/index.module.dev.js"
@@ -19,6 +20,7 @@
     },
     "./": "./",
     "./preact": {
+      "types": "./dist/index.d.ts",
       "browser": {
         "production": "./preact/index.module.js",
         "development": "./preact/index.module.dev.js"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Currently, when using reactivue with ESM and Node16 "moduleResolution" in TypeScript, TypeScript is unable to resolve the types because it resolves index.mjs in ESM mode and checks for a definition file named index.d.mts, which doesn't exist.

I fixed this by adding an explicit "types" property that points to index.d.ts inside the "exports" property, based on the screenshot of the docs below (screenshot from https://www.typescriptlang.org/docs/handbook/esm-node.html):

![image](https://user-images.githubusercontent.com/36966635/207108061-bbe20d4f-eb14-43eb-bc64-7e72fa017175.png)


### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
