### PR TITLE
fix: onMounted and watch not working in dev mode

### DIFF
--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -25,17 +25,6 @@ export let currentInstance: InternalInstanceState | null = null
 export let currentInstanceId: number | null = null
 
 export const getNewInstanceId = () => {
-  if (__DEV__) {
-    // When React is in Strict mode, it runs state functions twice
-    // Remove unmounted instances before creating new one
-    Object.keys(_vueState).forEach((id) => {
-      setTimeout(() => {
-        if (_vueState[+id]?.isActive === false)
-          unmount(+id)
-      }, 0)
-    })
-  }
-
   _id++
 
   if (__DEV__ && __BROWSER__)

--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -50,7 +50,6 @@ export const createNewInstanceWithId = (id: number, props: any, data: Ref<any> =
     _id: id,
     props,
     data,
-    isActive: false,
     isUnmounted: false,
     isUnmounting: false,
     hooks: {},

--- a/packages/reactivue/src/computed.ts
+++ b/packages/reactivue/src/computed.ts
@@ -5,7 +5,7 @@ import {
   WritableComputedRef,
   ComputedGetter,
 } from '@vue/reactivity'
-import { recordInstanceBoundEffect } from './component'
+import { recordInstanceBoundEffect, usingEffectScope } from './component'
 
 export function computed<T>(getter: ComputedGetter<T>): ComputedRef<T>
 export function computed<T>(
@@ -15,6 +15,6 @@ export function computed<T>(
   getterOrOptions: ComputedGetter<T> | WritableComputedOptions<T>,
 ) {
   const c = _computed(getterOrOptions as any)
-  recordInstanceBoundEffect(c.effect)
+  if (!usingEffectScope) recordInstanceBoundEffect(c.effect)
   return c
 }

--- a/packages/reactivue/src/lifecycle.ts
+++ b/packages/reactivue/src/lifecycle.ts
@@ -37,7 +37,7 @@ export function injectHook(
     if (prepend)
       hooks.unshift(wrappedHook)
 
-    else
+    else if (!target.isMounted)
       hooks.push(wrappedHook)
   }
   else if (__DEV__) {

--- a/packages/reactivue/src/types.ts
+++ b/packages/reactivue/src/types.ts
@@ -15,7 +15,6 @@ export interface InternalInstanceState {
   _id: number
   props: any
   data: Ref<any>
-  isActive: boolean
   isUnmounted: boolean
   isUnmounting: boolean
   effects?: ReactiveEffect[]

--- a/packages/reactivue/src/types.ts
+++ b/packages/reactivue/src/types.ts
@@ -1,4 +1,4 @@
-import { ReactiveEffect, Ref } from '@vue/reactivity'
+import { ReactiveEffect, Ref, EffectScope } from '@vue/reactivity'
 
 export const enum LifecycleHooks {
   BEFORE_CREATE = 'BeforeMount',
@@ -15,12 +15,15 @@ export interface InternalInstanceState {
   _id: number
   props: any
   data: Ref<any>
+  isActive: boolean
+  isMounted: boolean
   isUnmounted: boolean
   isUnmounting: boolean
   effects?: ReactiveEffect[]
   hooks: Record<string, Function[]>
   initialState: Record<any, any>
   provides: Record<string, unknown>
+  scope: EffectScope | null
 }
 
 export type InstanceStateMap = Record<number, InternalInstanceState>

--- a/packages/reactivue/src/useSetup.ts
+++ b/packages/reactivue/src/useSetup.ts
@@ -62,8 +62,6 @@ export function useSetup<State extends Record<any, any>, Props = {}>(
         if (!instance)
           return
 
-        instance.isActive = true
-
         if (!instance.isUnmounting)
           return
 

--- a/packages/reactivue/src/useSetup.ts
+++ b/packages/reactivue/src/useSetup.ts
@@ -88,6 +88,12 @@ export function useSetup<State extends Record<any, any>, Props = {}>(
     useInstanceScope(id, (instance) => {
       if (!instance)
         return
+      
+      // Avoid repeated execution of onMounted and watch after hmr updates in development mode
+      if (instance.isMounted)
+        return
+
+      instance.isMounted = true
 
       invokeLifeCycle(LifecycleHooks.MOUNTED)
 

--- a/packages/reactivue/src/watch.ts
+++ b/packages/reactivue/src/watch.ts
@@ -3,7 +3,8 @@
 /* eslint-disable array-callback-return */
 import { effect, Ref, ComputedRef, ReactiveEffectOptions, isRef, isReactive, stop } from '@vue/reactivity'
 import { isFunction, isArray, NOOP, isObject, remove, hasChanged } from '@vue/shared'
-import { currentInstance, recordInstanceBoundEffect } from './component'
+import { watch as _watch, watchEffect as _watchEffect } from '@vue/runtime-core'
+import { currentInstance, recordInstanceBoundEffect, usingEffectScope } from './component'
 import { warn, callWithErrorHandling, callWithAsyncErrorHandling } from './errorHandling'
 
 export type WatchEffect = (onInvalidate: InvalidateCbRegistrator) => void
@@ -51,6 +52,7 @@ export function watchEffect(
   effect: WatchEffect,
   options?: WatchOptionsBase,
 ): WatchStopHandle {
+  if (usingEffectScope) return _watchEffect(effect, options)
   return doWatch(effect, null, options)
 }
 
@@ -90,6 +92,7 @@ export function watch<T = any>(
   cb: WatchCallback<T>,
   options?: WatchOptions,
 ): WatchStopHandle {
+  if (usingEffectScope) return _watch(source, cb as any, options)
   return doWatch(source, cb, options)
 }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

In dev mode, when multiple components are rendered at the same time, only the onMounted method of the last component was triggered, and its data was reactive.

Reproducible demo: https://codesandbox.io/s/youthful-pond-ffv60s

![demo](https://user-images.githubusercontent.com/18415774/236662576-7a7c0f75-21b4-4b99-b26c-baa471fe4aed.gif)

We identified that the issue was caused by compatibility problems with React.StrictMode, and we resolved it by removing the compatibility.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
