### PR TITLE
fix: lifecycle and watch issues after hmr updates

### DIFF
--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -62,6 +62,7 @@ export const createNewInstanceWithId = (id: number, props: any, data: Ref<any> =
     props,
     data,
     isActive: false,
+    isMounted: false,
     isUnmounted: false,
     isUnmounting: false,
     hooks: {},

--- a/packages/reactivue/src/lifecycle.ts
+++ b/packages/reactivue/src/lifecycle.ts
@@ -37,7 +37,7 @@ export function injectHook(
     if (prepend)
       hooks.unshift(wrappedHook)
 
-    else
+    else if (!target.isMounted)
       hooks.push(wrappedHook)
   }
   else if (__DEV__) {

--- a/packages/reactivue/src/types.ts
+++ b/packages/reactivue/src/types.ts
@@ -16,6 +16,7 @@ export interface InternalInstanceState {
   props: any
   data: Ref<any>
   isActive: boolean
+  isMounted: boolean
   isUnmounted: boolean
   isUnmounting: boolean
   effects?: ReactiveEffect[]

--- a/packages/reactivue/src/useSetup.ts
+++ b/packages/reactivue/src/useSetup.ts
@@ -90,6 +90,12 @@ export function useSetup<State extends Record<any, any>, Props = {}>(
     useInstanceScope(id, (instance) => {
       if (!instance)
         return
+      
+      // Avoid repeated execution of onMounted and watch after hmr updates in development mode
+      if (instance.isMounted)
+        return
+
+      instance.isMounted = true
 
       invokeLifeCycle(LifecycleHooks.MOUNTED)
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fix the issue of lifecycle and listener anomalies after hot updates

- onMounted is executed repeatedly after a HMR (it should not be executed)
- onUpdated accumulates execution after a HMR (it should not accumulate)

Reproducible demo: https://codesandbox.io/s/goofy-mirzakhani-ew0mqv

![demo](https://user-images.githubusercontent.com/18415774/236662844-3d8f41e8-bc95-4f3c-85a7-f209bc08ed6f.gif)

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
