### PR TITLE
fix: onMounted and watch not working in dev mode

### DIFF
--- a/packages/reactivue/src/component.ts
+++ b/packages/reactivue/src/component.ts
@@ -25,17 +25,6 @@ export let currentInstance: InternalInstanceState | null = null
 export let currentInstanceId: number | null = null
 
 export const getNewInstanceId = () => {
-  if (__DEV__) {
-    // When React is in Strict mode, it runs state functions twice
-    // Remove unmounted instances before creating new one
-    Object.keys(_vueState).forEach((id) => {
-      setTimeout(() => {
-        if (_vueState[+id]?.isActive === false)
-          unmount(+id)
-      }, 0)
-    })
-  }
-
   _id++
 
   if (__DEV__ && __BROWSER__)
@@ -61,7 +50,6 @@ export const createNewInstanceWithId = (id: number, props: any, data: Ref<any> =
     _id: id,
     props,
     data,
-    isActive: false,
     isUnmounted: false,
     isUnmounting: false,
     hooks: {},

--- a/packages/reactivue/src/types.ts
+++ b/packages/reactivue/src/types.ts
@@ -15,7 +15,6 @@ export interface InternalInstanceState {
   _id: number
   props: any
   data: Ref<any>
-  isActive: boolean
   isUnmounted: boolean
   isUnmounting: boolean
   effects?: ReactiveEffect[]

--- a/packages/reactivue/src/useSetup.ts
+++ b/packages/reactivue/src/useSetup.ts
@@ -62,8 +62,6 @@ export function useSetup<State extends Record<any, any>, Props = {}>(
         if (!instance)
           return
 
-        instance.isActive = true
-
         if (!instance.isUnmounting)
           return
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

In dev mode, when multiple components are rendered at the same time, only the onMounted method of the last component was triggered, and its data was reactive.

Reproducible demo: https://codesandbox.io/s/youthful-pond-ffv60s

![demo](https://user-images.githubusercontent.com/18415774/236662576-7a7c0f75-21b4-4b99-b26c-baa471fe4aed.gif)

We identified that the issue was caused by compatibility problems with React.StrictMode, and we resolved it by removing the compatibility.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
